### PR TITLE
Improve auth pages layout and footer integration

### DIFF
--- a/plan-it/src/pages/LoginPage.tsx
+++ b/plan-it/src/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Navigation } from '@/components/layout/Navigation'
+import { Footer } from '@/components/layout/Footer'
 import heroImage from '@/assets/images/home/hero.png'
 
 export function LoginPage() {
@@ -62,7 +63,7 @@ export function LoginPage() {
     <div className="min-h-screen relative flex flex-col">
       {/* Background with same hero image and overlay */}
       <div 
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+        className="fixed inset-0 bg-cover bg-center bg-no-repeat -z-10"
         style={{
           backgroundImage: `url(${heroImage})`,
         }}
@@ -74,7 +75,7 @@ export function LoginPage() {
       <Navigation />
 
       {/* Login form */}
-      <div className="relative z-10 flex-1 flex items-center justify-center px-6 lg:px-8 mt-20">
+      <div className="relative z-10 flex-1 flex items-center justify-center px-6 lg:px-8 mt-32 mb-20">
         <Card className="w-full max-w-md bg-black/80 border-brand-green border-2 text-white">
           <CardHeader className="text-center">
             <CardTitle className="font-arial-black text-3xl text-brand-green mb-2">
@@ -138,21 +139,9 @@ export function LoginPage() {
         </Card>
       </div>
 
-      {/* Wave decoration at bottom */}
+      {/* Footer */}
       <div className="relative z-10">
-        <svg
-          viewBox="0 0 1200 120"
-          preserveAspectRatio="none"
-          className="w-full h-16 fill-brand-green"
-        >
-          <path d="M0,0V46.29c47.79,22.2,103.59,32.17,158,28,70.36-5.37,136.33-33.31,206.8-37.5C438.64,32.43,512.34,53.67,583,72.05c69.27,18,138.3,24.88,209.4,13.08,36.15-6,69.85-17.84,104.45-29.34C989.49,25,1113-14.29,1200,52.47V0Z"
-            opacity=".25"
-          ></path>
-          <path d="M0,0V15.81C13,36.92,27.64,56.86,47.69,72.05,99.41,111.27,165,111,224.58,91.58c31.15-10.15,60.09-26.07,89.67-39.8,40.92-19,84.73-46,130.83-49.67,36.26-2.85,70.9,9.42,98.6,31.56,31.77,25.39,62.32,62,103.63,73,40.44,10.79,81.35-6.69,119.13-24.28s75.16-39,116.92-43.05c59.73-5.85,113.28,22.88,168.9,38.84,30.2,8.66,59,6.17,87.09-7.5,22.43-10.89,48-26.93,60.65-49.24V0Z"
-            opacity=".5"
-          ></path>
-          <path d="M0,0V5.63C149.93,59,314.09,71.32,475.83,42.57c43-7.64,84.23-20.12,127.61-26.46,59-8.63,112.48,12.24,165.56,35.4C827.93,77.22,886,95.24,951.2,90c86.53-7,172.46-45.71,248.8-84.81V0Z"></path>
-        </svg>
+        <Footer />
       </div>
     </div>
   )

--- a/plan-it/src/pages/SignUpPage.tsx
+++ b/plan-it/src/pages/SignUpPage.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Navigation } from '@/components/layout/Navigation'
+import { Footer } from '@/components/layout/Footer'
 import heroImage from '@/assets/images/home/hero.png'
 
 export function SignUpPage() {
@@ -79,7 +80,7 @@ export function SignUpPage() {
     <div className="min-h-screen relative flex flex-col">
       {/* Background with same hero image and overlay */}
       <div 
-        className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+        className="fixed inset-0 bg-cover bg-center bg-no-repeat -z-10"
         style={{
           backgroundImage: `url(${heroImage})`,
         }}
@@ -91,7 +92,7 @@ export function SignUpPage() {
       <Navigation />
 
       {/* Sign up form */}
-      <div className="relative z-10 flex-1 flex items-center justify-center px-6 lg:px-8 py-12 mt-20">
+      <div className="relative z-10 flex-1 flex items-center justify-center px-6 lg:px-8 py-12 mt-20 mb-20">
         <Card className="w-full max-w-md bg-black/80 border-brand-green border-2 text-white">
           <CardHeader className="text-center">
             <CardTitle className="font-arial-black text-3xl text-brand-green mb-2">
@@ -256,21 +257,9 @@ export function SignUpPage() {
         </Card>
       </div>
 
-      {/* Wave decoration at bottom */}
+      {/* Footer */}
       <div className="relative z-10">
-        <svg
-          viewBox="0 0 1200 120"
-          preserveAspectRatio="none"
-          className="w-full h-16 fill-brand-green"
-        >
-          <path d="M0,0V46.29c47.79,22.2,103.59,32.17,158,28,70.36-5.37,136.33-33.31,206.8-37.5C438.64,32.43,512.34,53.67,583,72.05c69.27,18,138.3,24.88,209.4,13.08,36.15-6,69.85-17.84,104.45-29.34C989.49,25,1113-14.29,1200,52.47V0Z"
-            opacity=".25"
-          ></path>
-          <path d="M0,0V15.81C13,36.92,27.64,56.86,47.69,72.05,99.41,111.27,165,111,224.58,91.58c31.15-10.15,60.09-26.07,89.67-39.8,40.92-19,84.73-46,130.83-49.67,36.26-2.85,70.9,9.42,98.6,31.56,31.77,25.39,62.32,62,103.63,73,40.44,10.79,81.35-6.69,119.13-24.28s75.16-39,116.92-43.05c59.73-5.85,113.28,22.88,168.9,38.84,30.2,8.66,59,6.17,87.09-7.5,22.43-10.89,48-26.93,60.65-49.24V0Z"
-            opacity=".5"
-          ></path>
-          <path d="M0,0V5.63C149.93,59,314.09,71.32,475.83,42.57c43-7.64,84.23-20.12,127.61-26.46,59-8.63,112.48,12.24,165.56,35.4C827.93,77.22,886,95.24,951.2,90c86.53-7,172.46-45.71,248.8-84.81V0Z"></path>
-        </svg>
+        <Footer />
       </div>
     </div>
   )


### PR DESCRIPTION
- Replace green wave decorations with proper Footer component on login/signup pages
- Fix background image resizing issue by using fixed positioning with -z-10
- Add proper spacing with margin-bottom for footer visibility
- Increase top margin on login form for better header spacing (mt-32)
- Ensure footer displays above background overlay with z-index wrapper
- Maintain consistent layout and prevent content overlap

🤖 Generated with [Claude Code](https://claude.ai/code)