### PR TITLE
Fix event tile clickability for partner and attendee pages

### DIFF
--- a/plan-it/src/components/events/EventCard.tsx
+++ b/plan-it/src/components/events/EventCard.tsx
@@ -45,14 +45,20 @@ export function EventCard({ event, linkTo }: EventCardProps) {
       )}
       
       <CardHeader className="pb-3">
-        <Link 
-          to={`/event/${event.id}`}
-          className="block hover:no-underline"
-        >
+        {linkTo ? (
           <CardTitle className="text-xl font-arial-black text-brand-green hover:text-white transition-colors line-clamp-2 cursor-pointer">
             {event.title}
           </CardTitle>
-        </Link>
+        ) : (
+          <Link 
+            to={`/event/${event.id}`}
+            className="block hover:no-underline"
+          >
+            <CardTitle className="text-xl font-arial-black text-brand-green hover:text-white transition-colors line-clamp-2 cursor-pointer">
+              {event.title}
+            </CardTitle>
+          </Link>
+        )}
         <p className="text-gray-300 text-sm font-rubik">{event.organizationName}</p>
       </CardHeader>
       

--- a/plan-it/src/pages/attendee/AttendeeEventsPage.tsx
+++ b/plan-it/src/pages/attendee/AttendeeEventsPage.tsx
@@ -155,10 +155,16 @@ export function AttendeeEventsPage() {
           {filteredEvents.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
               {filteredEvents.map(event => (
-                <EventCard
-                  key={event.id}
-                  event={event}
-                />
+                <Link 
+                  key={event.id} 
+                  to={`/event/${event.id}`}
+                  className="block"
+                >
+                  <EventCard
+                    event={event}
+                    linkTo={`/event/${event.id}`}
+                  />
+                </Link>
               ))}
             </div>
           ) : (
@@ -190,10 +196,16 @@ export function AttendeeEventsPage() {
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
               {mockEvents.slice(0, 3).map(event => (
-                <EventCard
-                  key={`trending-${event.id}`}
-                  event={event}
-                />
+                <Link 
+                  key={`trending-${event.id}`} 
+                  to={`/event/${event.id}`}
+                  className="block"
+                >
+                  <EventCard
+                    event={event}
+                    linkTo={`/event/${event.id}`}
+                  />
+                </Link>
               ))}
             </div>
           </div>

--- a/plan-it/src/pages/attendee/MyEventsPage.tsx
+++ b/plan-it/src/pages/attendee/MyEventsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { Navigation } from '@/components/layout/Navigation'
 import { Footer } from '@/components/layout/Footer'
 import { EventCard } from '@/components/events/EventCard'
@@ -112,9 +113,14 @@ export function MyEventsPage() {
     const StatusIcon = status.icon
 
     return (
-      <div key={event.id} className="relative">
+      <Link 
+        key={event.id} 
+        to={`/event/${event.id}`}
+        className="block relative"
+      >
         <EventCard
           event={event}
+          linkTo={`/event/${event.id}`}
         />
         {/* Status Badge Overlay */}
         <div className="absolute top-3 left-3 z-10">
@@ -123,7 +129,7 @@ export function MyEventsPage() {
             {status.text}
           </Badge>
         </div>
-      </div>
+      </Link>
     )
   }
 

--- a/plan-it/src/pages/partner/PartnerEventsPage.tsx
+++ b/plan-it/src/pages/partner/PartnerEventsPage.tsx
@@ -256,7 +256,11 @@ export function PartnerEventsPage() {
                 const daysUntilDeadline = getDaysUntilDeadline(event.responseDeadline)
                 
                 return (
-                  <div key={event.id} className="relative">
+                  <Link 
+                    key={event.id} 
+                    to={`/partner/event/${event.id}`}
+                    className="block relative"
+                  >
                     {/* Enhanced Event Card with Partner-specific Info */}
                     <Card className="bg-black/80 border-brand-green border hover:border-brand-green/80 transition-all duration-300 hover:shadow-lg hover:shadow-brand-green/20 cursor-pointer group">
                       {/* Event Image */}
@@ -288,7 +292,7 @@ export function PartnerEventsPage() {
                       )}
                       
                       <CardHeader className="pb-3">
-                        <CardTitle className="text-xl font-arial-black text-brand-green group-hover:text-white transition-colors line-clamp-2">
+                        <CardTitle className="text-xl font-arial-black text-brand-green group-hover:text-white transition-colors line-clamp-2 cursor-pointer">
                           {event.title}
                         </CardTitle>
                         <p className="text-gray-300 text-sm font-rubik">{event.organizationName}</p>
@@ -349,23 +353,18 @@ export function PartnerEventsPage() {
                         
                         {/* Action */}
                         <div className="pt-2 border-t border-gray-700">
-                          <Link 
-                            to={`/partner/event/${event.id}`}
-                            className="block"
-                          >
-                            <div className="flex items-center justify-between">
-                              <span className="text-brand-green text-sm font-medium font-rubik">
-                                Submit Proposal →
-                              </span>
-                              <Badge className="bg-brand-green/20 text-brand-green border-brand-green text-xs">
-                                Open
-                              </Badge>
-                            </div>
-                          </Link>
+                          <div className="flex items-center justify-between">
+                            <span className="text-brand-green text-sm font-medium font-rubik">
+                              Submit Proposal →
+                            </span>
+                            <Badge className="bg-brand-green/20 text-brand-green border-brand-green text-xs">
+                              Open
+                            </Badge>
+                          </div>
                         </div>
                       </CardContent>
                     </Card>
-                  </div>
+                  </Link>
                 )
               })}
             </div>


### PR DESCRIPTION
- Make entire partner event tiles clickable (not just title)
- Fix attendee event cards to be fully clickable
- Remove nested Link conflicts to prevent navigation issues
- Partner tiles navigate to /partner/event/:id for proposal submission
- Attendee tiles navigate to /event/:id for general event details

🤖 Generated with [Claude Code](https://claude.ai/code)